### PR TITLE
Add unit tests for utils.py

### DIFF
--- a/deepcell_label_utils/schemas.py
+++ b/deepcell_label_utils/schemas.py
@@ -118,15 +118,21 @@ class SpatialLabelSchema(OrderedSchema):
 
     coordinate = fields.Dict(
         keys=fields.Int(),
-        values=fields.Nested(PointSchema)
+        values=fields.Dict(
+            keys=fields.Int(),
+            values=fields.Nested(PointSchema)
+        )
     )
 
     bbox = fields.Dict(
         keys=fields.Int(),
-        values=fields.List(
-            fields.Float(
-                required=True),
-            required=True)
+        values=fields.Dict(
+            keys=fields.Int(),
+            values=fields.List(
+                fields.Float(
+                    required=True),
+                required=True)
+        )
     )
 
     polygon = fields.Dict(
@@ -168,7 +174,8 @@ class CompartmentSchema(OrderedSchema):
 
 class CellSchema(NodeSchema):
     """ Fields specific to cell data entries"""
-    frames = fields.List(fields.Int(), description='Frames this cell appears in')
+    frames = fields.List(fields.Int(), description='Frames this \
+        cell appears in')
     spatial_label = fields.List(fields.Nested(CompartmentSchema()),
                                 description='Spatial labels')
 

--- a/deepcell_label_utils/schemas.py
+++ b/deepcell_label_utils/schemas.py
@@ -137,8 +137,11 @@ class SpatialLabelSchema(OrderedSchema):
 
     polygon = fields.Dict(
         keys=fields.Int(),
-        values=fields.Nested(MultiPolygonSchema),
-        description='Polygon'
+        values=fields.Dict(
+            keys=fields.Int(),
+            values=fields.Nested(MultiPolygonSchema),
+            description='Polygon'
+        )
     )
 
 

--- a/deepcell_label_utils/utils.py
+++ b/deepcell_label_utils/utils.py
@@ -151,8 +151,8 @@ class SpatialLabelConverter(object):
             time = object_info.iloc[i]['t']
             channel = object_info.iloc[i]['c']
             binary_mask[time, ..., channel] = np.where(
-                                        self.y[time, ..., channel] == value,
-                                        1, binary_mask[time, ..., channel])
+                self.y[time, ..., channel] == value,
+                1, binary_mask[time, ..., channel])
 
         return binary_mask
 

--- a/deepcell_label_utils/utils.py
+++ b/deepcell_label_utils/utils.py
@@ -25,13 +25,10 @@
 # ==============================================================================
 """Label utils"""
 
-# import json
-# import geojson
-import numpy as np
-import cv2
-
-from shapely.geometry import MultiPolygon, Polygon, Point  # , mapping
 from collections import defaultdict
+import cv2
+import numpy as np
+from shapely.geometry import MultiPolygon, Polygon, Point
 from skimage.measure import regionprops
 
 
@@ -115,6 +112,7 @@ class SpatialLabelConverter(object):
             mask = self.dcl_to_binary_mask(object_id)
             centroid = self.binary_mask_to_centroid(mask)
             bbox = self.binary_mask_to_bbox(mask)
+            # test_no_poly for unit tests below min_area for polygons
             if not test_no_poly:
                 polygon = self.binary_mask_to_polygon(mask)
 

--- a/deepcell_label_utils/utils_test.py
+++ b/deepcell_label_utils/utils_test.py
@@ -1,8 +1,8 @@
-from utils import SpatialLabelConverter, mask_to_polygons, polygons_to_mask
-from shapely.geometry import Point
-
 import numpy as np
 import pandas as pd
+from shapely.geometry import Point
+
+from utils import SpatialLabelConverter, mask_to_polygons, polygons_to_mask
 
 
 def test_get_object_ids():
@@ -209,14 +209,3 @@ def test_binary_mask_to_polygon():
                                                      expected_2[::-1]]
     assert polygon_3.geoms[0].exterior.coords[:] in [expected_2,
                                                      expected_2[::-1]]
-
-
-if __name__ == '__main__':
-    test_get_object_ids()
-    test_segments_to_dict()
-    test_dcl_to_binary_mask()
-    test_binary_mask_to_centroid()
-    test_binary_mask_to_bbox()
-    test_mask_to_polygons()
-    test_polygons_to_mask()
-    test_binary_mask_to_polygon()

--- a/deepcell_label_utils/utils_test.py
+++ b/deepcell_label_utils/utils_test.py
@@ -1,0 +1,165 @@
+from utils import SpatialLabelConverter
+from shapely.geometry import Point
+
+import numpy as np
+import pandas as pd
+
+
+def test_get_object_ids():
+    '''Test that the list of objects is obtained correctly.'''
+
+    # Simple example
+    X = np.array([[[[0], [0]], [[0], [0]]]])
+    y = np.array([[[[0], [0]], [[0], [0]]]])
+    segments = pd.DataFrame([{'cell': 1, 'value': 1, 'c': 0, 't': 0},
+                             {'cell': 2, 'value': 2, 'c': 0, 't': 0}])
+    SLC = SpatialLabelConverter(X, y, segments)
+    assert SLC.get_object_ids() == [1, 2]
+
+    # Test cases where a cell maps to multiple values
+    segments = pd.DataFrame([{'cell': 1, 'value': 1, 'c': 0, 't': 0},
+                             {'cell': 1, 'value': 2, 'c': 0, 't': 0}])
+    SLC = SpatialLabelConverter(X, y, segments)
+    assert SLC.get_object_ids() == [1]
+
+
+def test_segments_to_dict():
+    '''
+    Test that a segment dataframe is correctly converted
+    into list of dictionaries.
+    '''
+    X = np.array([[[[0], [0]], [[0], [0]]]])
+    y = np.array([[[[0], [0]], [[0], [0]]]])
+    segments = pd.DataFrame([{'cell': 1, 'value': 1, 'c': 0, 't': 0},
+                             {'cell': 2, 'value': 2, 'c': 0, 't': 0}])
+    SLC = SpatialLabelConverter(X, y, segments)
+    assert SLC.labels[1]['segment'] == [{'value': 1, 'c': 0, 't': 0}]
+    assert SLC.labels[2]['segment'] == [{'value': 2, 'c': 0, 't': 0}]
+
+
+def test_dcl_to_binary_mask():
+    '''
+    Test that binary masks are generated correctly
+    '''
+
+    # Set up overlapping segments (cells 1 and 3)
+    X = np.array([[[[0], [0]], [[0], [0]]]])
+    y = np.array([[[[1], [2]], [[3], [4]]]])
+    segments = pd.DataFrame([{'cell': 1, 'value': 1, 'c': 0, 't': 0},
+                             {'cell': 2, 'value': 2, 'c': 0, 't': 0},
+                             {'cell': 3, 'value': 3, 'c': 0, 't': 0},
+                             {'cell': 1, 'value': 4, 'c': 0, 't': 0},
+                             {'cell': 3, 'value': 4, 'c': 0, 't': 0}])
+    SLC = SpatialLabelConverter(X, y, segments)
+
+    # Binary masks 1 and 3 should both include bottom right pixel
+    assert(np.array_equal(SLC.dcl_to_binary_mask(1),
+                          np.array([[[[1], [0]], [[0], [1]]]])))
+    assert(np.array_equal(SLC.dcl_to_binary_mask(2),
+                          np.array([[[[0], [1]], [[0], [0]]]])))
+    assert(np.array_equal(SLC.dcl_to_binary_mask(3),
+                          np.array([[[[0], [0]], [[1], [1]]]])))
+
+    # Test case where num_channels > 1
+    X = np.array([[[[0, 0], [0, 0]], [[0, 0], [0, 0]]]])
+    y = np.array([[[[1, 1], [2, 1]], [[3, 1], [4, 1]]]])
+    segments = pd.DataFrame([{'cell': 1, 'value': 1, 'c': 0, 't': 0},
+                             {'cell': 2, 'value': 2, 'c': 0, 't': 0},
+                             {'cell': 3, 'value': 3, 'c': 0, 't': 0},
+                             {'cell': 1, 'value': 4, 'c': 0, 't': 0},
+                             {'cell': 3, 'value': 4, 'c': 0, 't': 0},
+                             {'cell': 1, 'value': 1, 'c': 1, 't': 0}])
+    SLC = SpatialLabelConverter(X, y, segments)
+    assert(np.array_equal(SLC.dcl_to_binary_mask(1),
+                          np.array([[[[1, 1], [0, 1]], [[0, 1], [1, 1]]]])))
+    assert(np.array_equal(SLC.dcl_to_binary_mask(2),
+                          np.array([[[[0, 0], [1, 0]], [[0, 0], [0, 0]]]])))
+    assert(np.array_equal(SLC.dcl_to_binary_mask(3),
+                          np.array([[[[0, 0], [0, 0]], [[1, 0], [1, 0]]]])))
+
+
+def test_binary_mask_to_centroid():
+    '''Test that centroids stored are correctly converted.'''
+    for i in range(2, 102, 2):
+        y = np.ones((1, i, i, 1), dtype=np.int8)
+        halved = i // 2
+        y[:, :, halved:i, :] = 2
+        X = np.zeros((1, i, i, 1))
+        segments = pd.DataFrame([{'cell': 1, 'value': 1, 'c': 0, 't': 0},
+                                 {'cell': 2, 'value': 2, 'c': 0, 't': 0}])
+        SLC = SpatialLabelConverter(X, y, segments)
+        OFFSET = 0.5  # 1,1 coordinate for skimage starts at 0.5, 0.5
+        assert(SLC.labels[1]['coordinate'][0][0] == Point(i / 2 - OFFSET,
+                                                          i / 4 - OFFSET))
+        assert(SLC.labels[2]['coordinate'][0][0] == Point(i / 2 - OFFSET,
+                                                          3 * i / 4 - OFFSET))
+
+    # Test case where num_channels > 1
+    i = 100
+    y = np.ones((1, i, i, 2), dtype=np.int8)
+    y[:, :, i//2:i, 0] = 2
+    y[:, :, i//2:i, 1] = 3
+    X = np.zeros((1, i, i, 2))
+    segments = pd.DataFrame([{'cell': 1, 'value': 1, 'c': 0, 't': 0},
+                             {'cell': 2, 'value': 2, 'c': 0, 't': 0},
+                             {'cell': 1, 'value': 1, 'c': 1, 't': 0},
+                             {'cell': 3, 'value': 3, 'c': 1, 't': 0}])
+    SLC = SpatialLabelConverter(X, y, segments)
+    OFFSET = 0.5  # 1,1 coordinate for skimage starts at 0.5, 0.5
+    assert(SLC.labels[1]['coordinate'][0][0] == Point(i / 2 - OFFSET,
+                                                      i / 4 - OFFSET))
+    assert(SLC.labels[2]['coordinate'][0][0] == Point(i / 2 - OFFSET,
+                                                      3 * i / 4 - OFFSET))
+    assert(SLC.labels[1]['coordinate'][0][1] == Point(i / 2 - OFFSET,
+                                                      i / 4 - OFFSET))
+    assert(SLC.labels[3]['coordinate'][0][1] == Point(i / 2 - OFFSET,
+                                                      3 * i / 4 - OFFSET))
+
+
+def test_binary_mask_to_bbox():
+    '''Test that bboxes are correctly converted from masks.'''
+    y = np.array([[[[1], [1], [1]], [[1], [1], [1]], [[2], [2], [2]]]])
+    X = np.zeros(y.shape)
+    segments = pd.DataFrame([{'cell': 1, 'value': 1, 'c': 0, 't': 0},
+                             {'cell': 2, 'value': 2, 'c': 0, 't': 0}])
+    SLC = SpatialLabelConverter(X, y, segments)
+    assert(SLC.labels[1]['bbox'][0][0] == [0, 0, 2, 3])
+    assert(SLC.labels[2]['bbox'][0][0] == [2, 0, 3, 3])
+
+    # Test the num_channels > 1 case
+    y = np.array([[[[1, 0], [1, 0], [1, 0]], [[1, 0],
+                 [1, 0], [1, 0]], [[1, 0], [1, 0], [1, 1]]]])
+    X = np.zeros(y.shape)
+    segments = pd.DataFrame([{'cell': 1, 'value': 1, 'c': 0, 't': 0},
+                             {'cell': 1, 'value': 1, 'c': 1, 't': 0}])
+    SLC = SpatialLabelConverter(X, y, segments)
+    assert(SLC.labels[1]['bbox'][0][0] == [0, 0, 3, 3])
+    assert(SLC.labels[1]['bbox'][0][1] == [2, 2, 3, 3])
+
+# def test_binary_mask_to_polygon():
+#     '''Test that polygons are correctly converted from masks.'''
+#     y = np.array([[[[1], [1], [1]], [[1], [1], [1]],
+#                  [[2], [2], [2]], [[2], [2], [2]]]])
+#     X = np.zeros(y.shape)
+#     segments = pd.DataFrame([{'cell': 1, 'value': 1, 'c': 0, 't': 0},
+#                              {'cell': 2, 'value': 2, 'c': 0, 't': 0}])
+#     SLC = SpatialLabelConverter(X, y, segments)
+#     print(SLC.labels[1]['polygon'][0][0])
+
+#     # # Test the num_channels > 1 case
+#     # y = np.array([[[[1, 0], [1, 0], [1, 0]],
+#                    [[1, 0], [1, 0], [1, 0]], [[1, 0], [1, 0], [1, 1]]]])
+#     # X = np.zeros(y.shape)
+#     # segments = pd.DataFrame([{'cell': 1, 'value': 1, 'c': 0, 't': 0},
+#     #                          {'cell': 1, 'value': 1, 'c': 1, 't': 0}])
+#     # SLC = SpatialLabelConverter(X, y, segments)
+#     # assert(SLC.labels[1]['bbox'][0][0] == [0, 0, 3, 3])
+#     # assert(SLC.labels[1]['bbox'][0][1] == [2, 2, 3, 3])
+
+if __name__ == '__main__':
+    test_get_object_ids()
+    test_segments_to_dict()
+    test_dcl_to_binary_mask()
+    test_binary_mask_to_centroid()
+    test_binary_mask_to_bbox()
+    # test_binary_mask_to_polygon()

--- a/deepcell_label_utils/utils_test.py
+++ b/deepcell_label_utils/utils_test.py
@@ -1,4 +1,4 @@
-from utils import SpatialLabelConverter
+from utils import SpatialLabelConverter, mask_to_polygons, polygons_to_mask
 from shapely.geometry import Point
 
 import numpy as np
@@ -13,13 +13,13 @@ def test_get_object_ids():
     y = np.array([[[[0], [0]], [[0], [0]]]])
     segments = pd.DataFrame([{'cell': 1, 'value': 1, 'c': 0, 't': 0},
                              {'cell': 2, 'value': 2, 'c': 0, 't': 0}])
-    SLC = SpatialLabelConverter(X, y, segments)
+    SLC = SpatialLabelConverter(X, y, segments, test_no_poly=True)
     assert SLC.get_object_ids() == [1, 2]
 
     # Test cases where a cell maps to multiple values
     segments = pd.DataFrame([{'cell': 1, 'value': 1, 'c': 0, 't': 0},
                              {'cell': 1, 'value': 2, 'c': 0, 't': 0}])
-    SLC = SpatialLabelConverter(X, y, segments)
+    SLC = SpatialLabelConverter(X, y, segments, test_no_poly=True)
     assert SLC.get_object_ids() == [1]
 
 
@@ -32,7 +32,7 @@ def test_segments_to_dict():
     y = np.array([[[[0], [0]], [[0], [0]]]])
     segments = pd.DataFrame([{'cell': 1, 'value': 1, 'c': 0, 't': 0},
                              {'cell': 2, 'value': 2, 'c': 0, 't': 0}])
-    SLC = SpatialLabelConverter(X, y, segments)
+    SLC = SpatialLabelConverter(X, y, segments, test_no_poly=True)
     assert SLC.labels[1]['segment'] == [{'value': 1, 'c': 0, 't': 0}]
     assert SLC.labels[2]['segment'] == [{'value': 2, 'c': 0, 't': 0}]
 
@@ -50,15 +50,15 @@ def test_dcl_to_binary_mask():
                              {'cell': 3, 'value': 3, 'c': 0, 't': 0},
                              {'cell': 1, 'value': 4, 'c': 0, 't': 0},
                              {'cell': 3, 'value': 4, 'c': 0, 't': 0}])
-    SLC = SpatialLabelConverter(X, y, segments)
+    SLC = SpatialLabelConverter(X, y, segments, test_no_poly=True)
 
     # Binary masks 1 and 3 should both include bottom right pixel
-    assert(np.array_equal(SLC.dcl_to_binary_mask(1),
-                          np.array([[[[1], [0]], [[0], [1]]]])))
-    assert(np.array_equal(SLC.dcl_to_binary_mask(2),
-                          np.array([[[[0], [1]], [[0], [0]]]])))
-    assert(np.array_equal(SLC.dcl_to_binary_mask(3),
-                          np.array([[[[0], [0]], [[1], [1]]]])))
+    assert np.array_equal(SLC.dcl_to_binary_mask(1),
+                          np.array([[[[1], [0]], [[0], [1]]]]))
+    assert np.array_equal(SLC.dcl_to_binary_mask(2),
+                          np.array([[[[0], [1]], [[0], [0]]]]))
+    assert np.array_equal(SLC.dcl_to_binary_mask(3),
+                          np.array([[[[0], [0]], [[1], [1]]]]))
 
     # Test case where num_channels > 1
     X = np.array([[[[0, 0], [0, 0]], [[0, 0], [0, 0]]]])
@@ -69,13 +69,13 @@ def test_dcl_to_binary_mask():
                              {'cell': 1, 'value': 4, 'c': 0, 't': 0},
                              {'cell': 3, 'value': 4, 'c': 0, 't': 0},
                              {'cell': 1, 'value': 1, 'c': 1, 't': 0}])
-    SLC = SpatialLabelConverter(X, y, segments)
-    assert(np.array_equal(SLC.dcl_to_binary_mask(1),
-                          np.array([[[[1, 1], [0, 1]], [[0, 1], [1, 1]]]])))
-    assert(np.array_equal(SLC.dcl_to_binary_mask(2),
-                          np.array([[[[0, 0], [1, 0]], [[0, 0], [0, 0]]]])))
-    assert(np.array_equal(SLC.dcl_to_binary_mask(3),
-                          np.array([[[[0, 0], [0, 0]], [[1, 0], [1, 0]]]])))
+    SLC = SpatialLabelConverter(X, y, segments, test_no_poly=True)
+    assert np.array_equal(SLC.dcl_to_binary_mask(1),
+                          np.array([[[[1, 1], [0, 1]], [[0, 1], [1, 1]]]]))
+    assert np.array_equal(SLC.dcl_to_binary_mask(2),
+                          np.array([[[[0, 0], [1, 0]], [[0, 0], [0, 0]]]]))
+    assert np.array_equal(SLC.dcl_to_binary_mask(3),
+                          np.array([[[[0, 0], [0, 0]], [[1, 0], [1, 0]]]]))
 
 
 def test_binary_mask_to_centroid():
@@ -87,12 +87,12 @@ def test_binary_mask_to_centroid():
         X = np.zeros((1, i, i, 1))
         segments = pd.DataFrame([{'cell': 1, 'value': 1, 'c': 0, 't': 0},
                                  {'cell': 2, 'value': 2, 'c': 0, 't': 0}])
-        SLC = SpatialLabelConverter(X, y, segments)
+        SLC = SpatialLabelConverter(X, y, segments, test_no_poly=True)
         OFFSET = 0.5  # 1,1 coordinate for skimage starts at 0.5, 0.5
-        assert(SLC.labels[1]['coordinate'][0][0] == Point(i / 2 - OFFSET,
-                                                          i / 4 - OFFSET))
-        assert(SLC.labels[2]['coordinate'][0][0] == Point(i / 2 - OFFSET,
-                                                          3 * i / 4 - OFFSET))
+        assert SLC.labels[1]['coordinate'][0][0] == Point(i / 2 - OFFSET,
+                                                          i / 4 - OFFSET)
+        assert SLC.labels[2]['coordinate'][0][0] == Point(i / 2 - OFFSET,
+                                                          3 * i / 4 - OFFSET)
 
     # Test case where num_channels > 1
     i = 100
@@ -104,16 +104,16 @@ def test_binary_mask_to_centroid():
                              {'cell': 2, 'value': 2, 'c': 0, 't': 0},
                              {'cell': 1, 'value': 1, 'c': 1, 't': 0},
                              {'cell': 3, 'value': 3, 'c': 1, 't': 0}])
-    SLC = SpatialLabelConverter(X, y, segments)
+    SLC = SpatialLabelConverter(X, y, segments, test_no_poly=True)
     OFFSET = 0.5  # 1,1 coordinate for skimage starts at 0.5, 0.5
-    assert(SLC.labels[1]['coordinate'][0][0] == Point(i / 2 - OFFSET,
-                                                      i / 4 - OFFSET))
-    assert(SLC.labels[2]['coordinate'][0][0] == Point(i / 2 - OFFSET,
-                                                      3 * i / 4 - OFFSET))
-    assert(SLC.labels[1]['coordinate'][0][1] == Point(i / 2 - OFFSET,
-                                                      i / 4 - OFFSET))
-    assert(SLC.labels[3]['coordinate'][0][1] == Point(i / 2 - OFFSET,
-                                                      3 * i / 4 - OFFSET))
+    assert SLC.labels[1]['coordinate'][0][0] == Point(i / 2 - OFFSET,
+                                                      i / 4 - OFFSET)
+    assert SLC.labels[2]['coordinate'][0][0] == Point(i / 2 - OFFSET,
+                                                      3 * i / 4 - OFFSET)
+    assert SLC.labels[1]['coordinate'][0][1] == Point(i / 2 - OFFSET,
+                                                      i / 4 - OFFSET)
+    assert SLC.labels[3]['coordinate'][0][1] == Point(i / 2 - OFFSET,
+                                                      3 * i / 4 - OFFSET)
 
 
 def test_binary_mask_to_bbox():
@@ -122,9 +122,9 @@ def test_binary_mask_to_bbox():
     X = np.zeros(y.shape)
     segments = pd.DataFrame([{'cell': 1, 'value': 1, 'c': 0, 't': 0},
                              {'cell': 2, 'value': 2, 'c': 0, 't': 0}])
-    SLC = SpatialLabelConverter(X, y, segments)
-    assert(SLC.labels[1]['bbox'][0][0] == [0, 0, 2, 3])
-    assert(SLC.labels[2]['bbox'][0][0] == [2, 0, 3, 3])
+    SLC = SpatialLabelConverter(X, y, segments, test_no_poly=True)
+    assert SLC.labels[1]['bbox'][0][0] == [0, 0, 2, 3]
+    assert SLC.labels[2]['bbox'][0][0] == [2, 0, 3, 3]
 
     # Test the num_channels > 1 case
     y = np.array([[[[1, 0], [1, 0], [1, 0]], [[1, 0],
@@ -132,29 +132,84 @@ def test_binary_mask_to_bbox():
     X = np.zeros(y.shape)
     segments = pd.DataFrame([{'cell': 1, 'value': 1, 'c': 0, 't': 0},
                              {'cell': 1, 'value': 1, 'c': 1, 't': 0}])
+    SLC = SpatialLabelConverter(X, y, segments, test_no_poly=True)
+    assert SLC.labels[1]['bbox'][0][0] == [0, 0, 3, 3]
+    assert SLC.labels[1]['bbox'][0][1] == [2, 2, 3, 3]
+
+
+def test_mask_to_polygons():
+    # Test case for a time and channel slice
+    mask = np.zeros((100, 100), dtype='uint8')
+    mask[25:76, 25:76] = 1
+    polygon = mask_to_polygons(mask)
+    expected = [(25, 25), (25, 75), (75, 75), (75, 25), (25, 25)]
+    assert polygon.is_valid
+    assert polygon.geoms[0].exterior.coords[:] == expected
+
+
+def test_polygons_to_mask():
+    # Test that converting to and back gives initial mask
+    mask = np.zeros((100, 100), dtype='uint8')
+    mask[25:76, 25:76] = 1
+    polygon = mask_to_polygons(mask)
+    new_mask = polygons_to_mask(polygon, mask.shape)
+    assert np.array_equal(mask, new_mask)
+
+
+def test_binary_mask_to_polygon():
+    '''Test that polygons are correctly converted from masks.'''
+    y = np.ones((1, 100, 100, 1), dtype='uint8')
+    y[:, 50:100, :, :] = 2
+    X = np.zeros(y.shape)
+    segments = pd.DataFrame([{'cell': 1, 'value': 1, 'c': 0, 't': 0},
+                             {'cell': 2, 'value': 2, 'c': 0, 't': 0}])
     SLC = SpatialLabelConverter(X, y, segments)
-    assert(SLC.labels[1]['bbox'][0][0] == [0, 0, 3, 3])
-    assert(SLC.labels[1]['bbox'][0][1] == [2, 2, 3, 3])
+    polygon_1 = SLC.labels[1]['polygon'][0][0]
+    polygon_2 = SLC.labels[2]['polygon'][0][0]
+    # Should x or y be first? If x then use these comments instead:
+    # expected_1 = [(0, 0), (0, 99), (49, 99), (49, 0), (0, 0)])
+    # expected_2 = [(50, 0), (50, 99), (99, 99), (99, 0), (50, 0)])
+    expected_1 = [(0, 0), (99, 0), (99, 49), (0, 49), (0, 0)]
+    expected_2 = [(0, 50), (99, 50), (99, 99), (0, 99), (0, 50)]
+    assert polygon_1.is_valid
+    assert polygon_2.is_valid
+    assert polygon_1.geoms[0].exterior.coords[:] in [expected_1,
+                                                     expected_1[::-1]]
+    assert polygon_2.geoms[0].exterior.coords[:] in [expected_2,
+                                                     expected_2[::-1]]
 
-# def test_binary_mask_to_polygon():
-#     '''Test that polygons are correctly converted from masks.'''
-#     y = np.array([[[[1], [1], [1]], [[1], [1], [1]],
-#                  [[2], [2], [2]], [[2], [2], [2]]]])
-#     X = np.zeros(y.shape)
-#     segments = pd.DataFrame([{'cell': 1, 'value': 1, 'c': 0, 't': 0},
-#                              {'cell': 2, 'value': 2, 'c': 0, 't': 0}])
-#     SLC = SpatialLabelConverter(X, y, segments)
-#     print(SLC.labels[1]['polygon'][0][0])
+    # Test the num_channels > 1 case
+    y = np.ones((1, 100, 100, 2), dtype='uint8')
+    y[:, 50:100, :, 0] = 2
+    y[:, 50:100, :, 1] = 3
+    X = np.zeros(y.shape)
+    segments = pd.DataFrame([{'cell': 1, 'value': 1, 'c': 0, 't': 0},
+                             {'cell': 2, 'value': 2, 'c': 0, 't': 0},
+                             {'cell': 1, 'value': 1, 'c': 1, 't': 0},
+                             {'cell': 3, 'value': 3, 'c': 1, 't': 0}])
+    SLC = SpatialLabelConverter(X, y, segments)
+    polygon_1a = SLC.labels[1]['polygon'][0][0]
+    polygon_1b = SLC.labels[1]['polygon'][0][1]
+    polygon_2 = SLC.labels[2]['polygon'][0][0]
+    polygon_3 = SLC.labels[3]['polygon'][0][1]
+    # Should x or y be first? If y, then use these comments instead:
+    # expected_1 = [(0, 0), (0, 99), (49, 99), (49, 0), (0, 0)])
+    # expected_2 = [(50, 0), (50, 99), (99, 99), (99, 0), (50, 0)])
+    expected_1 = [(0, 0), (99, 0), (99, 49), (0, 49), (0, 0)]
+    expected_2 = [(0, 50), (99, 50), (99, 99), (0, 99), (0, 50)]
+    assert polygon_1a.is_valid
+    assert polygon_1b.is_valid
+    assert polygon_2.is_valid
+    assert polygon_3.is_valid
+    assert polygon_1a.geoms[0].exterior.coords[:] in [expected_1,
+                                                      expected_1[::-1]]
+    assert polygon_1b.geoms[0].exterior.coords[:] in [expected_1,
+                                                      expected_1[::-1]]
+    assert polygon_2.geoms[0].exterior.coords[:] in [expected_2,
+                                                     expected_2[::-1]]
+    assert polygon_3.geoms[0].exterior.coords[:] in [expected_2,
+                                                     expected_2[::-1]]
 
-#     # # Test the num_channels > 1 case
-#     # y = np.array([[[[1, 0], [1, 0], [1, 0]],
-#                    [[1, 0], [1, 0], [1, 0]], [[1, 0], [1, 0], [1, 1]]]])
-#     # X = np.zeros(y.shape)
-#     # segments = pd.DataFrame([{'cell': 1, 'value': 1, 'c': 0, 't': 0},
-#     #                          {'cell': 1, 'value': 1, 'c': 1, 't': 0}])
-#     # SLC = SpatialLabelConverter(X, y, segments)
-#     # assert(SLC.labels[1]['bbox'][0][0] == [0, 0, 3, 3])
-#     # assert(SLC.labels[1]['bbox'][0][1] == [2, 2, 3, 3])
 
 if __name__ == '__main__':
     test_get_object_ids()
@@ -162,4 +217,6 @@ if __name__ == '__main__':
     test_dcl_to_binary_mask()
     test_binary_mask_to_centroid()
     test_binary_mask_to_bbox()
-    # test_binary_mask_to_polygon()
+    test_mask_to_polygons()
+    test_polygons_to_mask()
+    test_binary_mask_to_polygon()

--- a/deepcell_label_utils/utils_test.py
+++ b/deepcell_label_utils/utils_test.py
@@ -97,8 +97,8 @@ def test_binary_mask_to_centroid():
     # Test case where num_channels > 1
     i = 100
     y = np.ones((1, i, i, 2), dtype=np.int8)
-    y[:, :, i//2:i, 0] = 2
-    y[:, :, i//2:i, 1] = 3
+    y[:, :, i // 2:i, 0] = 2
+    y[:, :, i // 2:i, 1] = 3
     X = np.zeros((1, i, i, 2))
     segments = pd.DataFrame([{'cell': 1, 'value': 1, 'c': 0, 't': 0},
                              {'cell': 2, 'value': 2, 'c': 0, 't': 0},

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,8 @@ with open(os.path.join(here, 'requirements.txt'), 'r') as f:
 
 VERSION = '0.0.1'
 NAME = 'DeepCell_Label_Utils'
-DESCRIPTION = 'Utility functions for reading and writing DeepCell annotated files.'
+DESCRIPTION = 'Utility functions for reading and \
+    writing DeepCell annotated files.'
 LICENSE = 'LICENSE'
 AUTHOR = 'Van Valen Lab'
 AUTHOR_EMAIL = 'vanvalenlab@gmail.com'


### PR DESCRIPTION
* Added unit tests for all conversion functions
* PEP8 style changes
* Refactored bbox, centroid, and polygon conversion functions to account for channel axis (assumes TYXC dimension order for input format)
* Still to-do: 
    * Direct conversion functions from DCL zip file that can streamline into the current schema
    * Write tests for schema.py